### PR TITLE
Add Model D2 Pro

### DIFF
--- a/src/glorious.rs
+++ b/src/glorious.rs
@@ -12,4 +12,5 @@ pub enum Device {
     WiredModelO = 0x2022,
     WiredModelD = 0x2023,
     WiredModelOMinus = 0x2024,
+    ModelD2Pro = 0x2034,
 }


### PR DESCRIPTION
I tested it with a few keybind commands such as:

```
cargo run config bind dpi-btn mouse back
```

and it seems to work.

Unfortunately I can't find a way to bind the DPI button to something useful (something other than btn 1,2,3,4,5) which can be picked up by Karabiner Elements so I'm going to return the mouse. Let me know if you have any ideas/tricks though :)