### PR TITLE
Add udev rules file

### DIFF
--- a/70-glorious-mxw.rules
+++ b/70-glorious-mxw.rules
@@ -1,0 +1,29 @@
+# Use these udev rules to allow `mxw` to communicate with wireless Glorious mice without privelige escalation (sudo)
+
+# HIDAPI/hidraw
+# TAG+="uaccess" only gives permission to physically present users
+# Model O Wireless 	(Wireless, Wired)
+KERNEL=="hidraw*", ATTRS{idVendor}=="258a", ATTRS{idProduct}=="2022", TAG+="uaccess"
+KERNEL=="hidraw*", ATTRS{idVendor}=="258a", ATTRS{idProduct}=="2011", TAG+="uaccess"
+
+# Model O- Wireless 	(Wireless, Wired)
+KERNEL=="hidraw*", ATTRS{idVendor}=="258a", ATTRS{idProduct}=="2013", TAG+="uaccess"
+KERNEL=="hidraw*", ATTRS{idVendor}=="258a", ATTRS{idProduct}=="2024", TAG+="uaccess"
+
+# Model O PRO 		(Wireless, Wired)
+KERNEL=="hidraw*", ATTRS{idVendor}=="258a", ATTRS{idProduct}=="2027", TAG+="uaccess"
+KERNEL=="hidraw*", ATTRS{idVendor}=="258a", ATTRS{idProduct}=="2015", TAG+="uaccess"
+
+# Model D Wireless 	(Wireless, Wired)
+KERNEL=="hidraw*", ATTRS{idVendor}=="258a", ATTRS{idProduct}=="2023", TAG+="uaccess"
+KERNEL=="hidraw*", ATTRS{idVendor}=="258a", ATTRS{idProduct}=="2012", TAG+="uaccess"
+
+# Model D- Wireless 	(Wireless, ~~Wired~~)
+KERNEL=="hidraw*", ATTRS{idVendor}=="258a", ATTRS{idProduct}=="2025", TAG+="uaccess"
+# Wired ID unknown, please help by contributing the wired USB ID if you have a Model D-. 
+
+# Model D2 PRO 		(Wireless)
+KERNEL=="hidraw*", ATTRS{idVendor}=="258a", ATTRS{idProduct}=="2034", TAG+="uaccess"
+
+# Series 1 PRO 		(Wireless)
+KERNEL=="hidraw*", ATTRS{idVendor}=="258a", ATTRS{idProduct}=="2018", TAG+="uaccess"

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ This project currently only works with these mice, as they are compatible with [
 
 ## Common issues
 - You get an error message like `Error: hidapi error: Failed to open a device with path '/dev/hidraw5': Permission denied`
-    - You can bypass this for the current session by running `sudo chmod a+rw /dev/hidraw5`.
-    - Use a [HID rule](https://github.com/libusb/hidapi/blob/master/udev/69-hid.rules) for a more permanent fix. All relevant information you would need to fill in is in [`glorious.rs`](https://github.com/dkbednarczyk/mxw/blob/master/src/glorious.rs).
+    - You can bypass this for the current session by running `sudo chmod a+rw /dev/hidraw5` (not recommended).
+    - Place this [udev rule](/70-glorious-mxw.rules) file in `/etc/udev/rules.d/`.
     - Install the [`mxw-udev`](https://aur.archlinux.org/packages/mxw-udev) AUR package on Arch Linux. 
 
 ## Installation


### PR DESCRIPTION
`mxw` requires udev rules to be applied in order function rootlessly. It would help to have pre-configured rules in the repository. 

I am also the maintainer of the [`mxw-udev`](https://aur.archlinux.org/packages/mxw-udev) package on the AUR. Having the udev rules file in this repository would simplify package maintenance and better align with AUR best practices. 