### PR TITLE
Add --uniform flag to config dpi-stages

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -125,6 +125,15 @@ pub enum Config {
         )]
         profile: u8,
 
+        /// Set every stage in the profile to this DPI, keeping the current stage count
+        #[arg(
+            short, long,
+            value_name = "DPI",
+            value_parser = value_parser!(u16).range(100..=19000),
+            conflicts_with = "stage",
+        )]
+        uniform: Option<u16>,
+
         #[arg(
             name = "stage",
             num_args(1..=6),

--- a/src/config/dpi_stages.rs
+++ b/src/config/dpi_stages.rs
@@ -1,8 +1,17 @@
 use crate::config::{dpi_stage, MAX_DPI_STAGES};
+use crate::report;
 use anyhow::{anyhow, Result};
 use hidapi::HidDevice;
 
-pub fn set(device: &HidDevice, profile: u8, stages: Vec<u16>) -> Result<()> {
+pub fn set(device: &HidDevice, profile: u8, stages: Vec<u16>, uniform: Option<u16>) -> Result<()> {
+    let stages = match uniform {
+        // Fill every stage the profile currently has with the same value.
+        // Reading the count back is unavoidable here: "all stages" is defined
+        // by the device's current configuration, not by anything on the CLI.
+        Some(dpi) => vec![dpi; report::dpi::count(device, profile)? as usize],
+        None => stages,
+    };
+
     if stages.is_empty() || stages.len() > MAX_DPI_STAGES as usize {
         return Err(anyhow!(
             "must provide between 1 and {MAX_DPI_STAGES} DPI stages"

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,9 +100,11 @@ fn main() -> Result<()> {
                 Config::DPIStage { profile, id } => config::dpi_stage::set(&device, profile, id),
 
                 // mxw config dpi-stages <STAGES>...
-                Config::DPIStages { profile, stages } => {
-                    config::dpi_stages::set(&device, profile, stages)
-                }
+                Config::DPIStages {
+                    profile,
+                    uniform,
+                    stages,
+                } => config::dpi_stages::set(&device, profile, stages, uniform),
 
                 // mxw config dpi-colors <COLORS>...
                 Config::DPIColors { profile, colors } => {


### PR DESCRIPTION
`config dpi-stages -u <DPI>` sets every stage in the profile to the same resolution while keeping the profile's current stage count, reading that count back from the device. This is the safe way to get a single effective DPI: a genuine one-stage list can leave some mice unresponsive until they are replugged, whereas N identical stages behave as one while cycling.

Conflicts with an explicit stage list; the default list is unaffected.